### PR TITLE
Hide the scanning output before the scan renders the output. issue#63

### DIFF
--- a/src/mainScanner.py
+++ b/src/mainScanner.py
@@ -103,7 +103,7 @@ def input():
 
     # Printing the information to screen
     print 'Scanning Completed in: ', total
-    return render_template('index.html', portnum=portnum, host=remoteServerIP, range_low=range_low, range_high=range_high, total=total)
+    return render_template('input.html', portnum=portnum, host=remoteServerIP, range_low=range_low, range_high=range_high, total=total)
 
 
 if __name__ == '__main__':

--- a/src/templates/input.html
+++ b/src/templates/input.html
@@ -82,6 +82,24 @@
                         <input type="submit" value="Scan Now" id="scan-port-button" class="lighten-3 btn-flat">
                     </div>
                 </form>
+                <h5>Scanning remote host {{ host }} between range {{ range_low }} to {{ range_high }} :</h5>
+                <table class="highlight responsive-table">
+                    <thead>
+                        <tr>
+                            <th>Port Number</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for port in portnum %}
+                        <tr>
+                            <td>{{ port }}</td>
+                            <td>Open</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <h5>Scanning completed in {{ total }} time.</h5>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Description

[BUG] Hide the scanning output before the scan renders the output. 

Fixes # (issue) 63

## Type of change
1. Deleted the scan results from src\templates\index.html.
2. Added a file src\templates\input.html to render this file for /input route.
3. Changed the src\mainScanner.py app.route to render_template src\templates\input.html

@vinitshahdeo @Kashish121 @ishika1727 