### PR TITLE
Add environment folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,16 @@ typings/
 .env
 .env.test
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pythonenv*
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 


### PR DESCRIPTION
# Description
I'm adding the folders associated with Python virtual environments to the gitignore file as well, since they should not be placed under version control.
