### PR TITLE
Fix Bad Magic Number Error by not generating Bytecodes

### DIFF
--- a/src/ipscanner.py
+++ b/src/ipscanner.py
@@ -1,3 +1,4 @@
+import sys; sys.dont_write_bytecode = True
 import socket
 from datetime import datetime
 import json

--- a/src/mainScanner.py
+++ b/src/mainScanner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+import sys; sys.dont_write_bytecode = True
 import socket
 import subprocess
-import sys
 from datetime import datetime
 import json
 import os

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+import sys; sys.dont_write_bytecode = True
 import socket
 import subprocess
-import sys
 from datetime import datetime
 import json
 import os

--- a/src/single/scanner.py
+++ b/src/single/scanner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+import sys; sys.dont_write_bytecode = True
 import socket
 import subprocess
-import sys
 from datetime import datetime
 
 # Clear the screen


### PR DESCRIPTION
# Description

This fixes the bad magic number error which is caused when user tries to run Flask UI through Python3, assuming the user has already tried running the Flask UI through Python2.
This also fixes potential bad magic number error when using over CLI.

Fixes #150 #127 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added the reviewer: @Kashish121 
